### PR TITLE
Add availability metrics and timeline

### DIFF
--- a/docs/revenue-loss-demo/README.md
+++ b/docs/revenue-loss-demo/README.md
@@ -132,7 +132,7 @@ The results are presented through several KPIs and charts:
     - `Time Availability (A_time %)` for the selected window.
     - `Value-Based Availability (A_dispatch %)`; the configured `P_min` is shown in the legend.
     - `(Optional) Price-Weighted Availability (A_econ %)` if price-weighting is enabled.
-    - **Headroom Cost (EUR)** and **Distance to Breach** (minutes of additional downtime until a 95% SLA would be breached).
+    - **Headroom Cost (EUR)** and **Distance to Breach** (minutes of additional downtime until a 95% time-based SLA would be breached). The SLA threshold compares `A_time` against the configured percentage.
 
 -   **Availability Timeline**: Ribbon view over time per battery with segments colored as *Available*, *Derated* (partial availability), and *Downtime*. Price or predicted power can be overlaid to highlight high-value periods.
 

--- a/docs/revenue-loss-demo/README.md
+++ b/docs/revenue-loss-demo/README.md
@@ -91,7 +91,7 @@ Availability is computed on the same 5-minute intervals.
 
 -   **Value-Based Availability (`A_dispatch`)**
     Evaluates availability only when the battery was expected to operate (charge or discharge), using the predicted schedule:
-    - Define an “instructed” slice when `abs(pred_power_kw) >= P_min`. (`P_min` is configurable; default is **5% of battery power rating**.)
+    - Define an “instructed”(that will be taken into calculation, so we don't count slices with very low charge/discharge) slice when `abs(pred_power_kw) >= P_min`. (`P_min` is configurable; default is **5% of battery power rating**.)
     - For instructed slices, compute partial availability:
       `a(t) = min(1, abs(act_power_kw) / abs(pred_power_kw))`
     - For non-instructed slices, set `a(t) = 1` (they do not penalize the score).
@@ -131,7 +131,7 @@ The results are presented through several KPIs and charts:
     - `Time Availability (A_time %)` for the selected window.
     - `Value-Based Availability (A_dispatch %)`; the configured `P_min` is shown in the legend.
     - `(Optional) Price-Weighted Availability (A_econ %)` if price-weighting is enabled.
-    - **Headroom Cost (EUR)** and **Distance to Breach** (minutes of additional downtime until a 95% time-based SLA would be breached). The SLA threshold compares `A_time` against the configured percentage.
+    - **Headroom Cost (EUR)** (money you're losing while still passing SLA) and **Distance to Breach** (minutes of additional downtime until a 95% SLA would be breached).
 
 -   **Availability Timeline**: Ribbon view over time per battery with segments colored as *Available*, *Derated* (partial availability), and *Downtime*. Price or predicted power can be overlaid to highlight high-value periods.
 

--- a/docs/revenue-loss-demo/README.md
+++ b/docs/revenue-loss-demo/README.md
@@ -104,9 +104,8 @@ Availability is computed on the same 5-minute intervals.
     - `A_econ = (Σ a(t) * w(t)) / (Σ w(t))`
 
 -   **Headroom Cost (informational)**
-    Monetized shortfall during periods that do **not** breach a time-based SLA threshold (e.g., 95%):
-    `Headroom Cost (EUR) = Σ ((abs(pred_power_kw) - abs(act_power_kw))⁺ * (5/60) * (price_eur_mwh/1000))`
-    computed over slices where the rolling/windowed `A_time` remains ≥ the SLA target.
+    Net revenue impact of deviations while the time-based SLA is satisfied; under-charging yields negative values (savings):
+    `Headroom Cost (EUR) = Σ (rev_pred_eur − rev_act_eur)` over non-DOWNTIME slices where the rolling/windowed `A_time` remains ≥ the SLA target.
 
 ## 3. Display & Visualization
 

--- a/docs/revenue-loss-demo/app.js
+++ b/docs/revenue-loss-demo/app.js
@@ -184,6 +184,7 @@ function computeDiffRows(price5, pred5, act5, batteries) {
   return rows;
 }
 
+// sla: target time-based availability fraction (e.g., 0.95 for 95% A_time)
 function aggregateSummaries(diffRows, batteries, pMinFrac, sla) {
   const perMap = new Map();
   const bmap = new Map(batteries.map(b => [b.battery_id, b]));
@@ -643,7 +644,7 @@ async function runCalculation() {
     const pMinPct = Number(document.getElementById('pMinPct').value) || 5;
     const slaPct = Number(document.getElementById('slaPct').value) || 95;
     const pMinFrac = pMinPct / 100;
-    const sla = slaPct / 100;
+    const sla = slaPct / 100; // SLA threshold for time-based availability (A_time)
     const { perBattery, portfolio } = aggregateSummaries(diffRows, batteries, pMinFrac, sla);
     renderKPIs(portfolio);
     renderSummaryTable(perBattery);

--- a/docs/revenue-loss-demo/index.html
+++ b/docs/revenue-loss-demo/index.html
@@ -29,6 +29,10 @@
       <label>Start <input type="datetime-local" id="startTs" /></label>
       <label>End <input type="datetime-local" id="endTs" /></label>
     </div>
+    <div class="input-group">
+      <label>P_min % <input type="number" id="pMinPct" value="5" min="0" max="100" /></label>
+      <label>SLA % <input type="number" id="slaPct" value="95" min="0" max="100" /></label>
+    </div>
     <button id="runBtn">Run Calculation</button>
   </div>
 
@@ -54,6 +58,9 @@
     <h2>Loss Heatmap</h2>
     <div class="input-group"><label>Metric <select id="heatmapMetric"><option value="loss">Loss EUR</option><option value="error">Dispatch Error</option></select></label></div>
     <div id="heatmap" class="heatmap"></div>
+
+    <h2>Availability Timeline</h2>
+    <div id="availTimeline" class="heatmap"></div>
 
     <h2>Loss Breakdown by Cause</h2>
     <canvas id="lossBreakdown"></canvas>

--- a/docs/revenue-loss-demo/index.html
+++ b/docs/revenue-loss-demo/index.html
@@ -31,7 +31,7 @@
     </div>
     <div class="input-group">
       <label>P_min % <input type="number" id="pMinPct" value="5" min="0" max="100" /></label>
-      <label>SLA % <input type="number" id="slaPct" value="95" min="0" max="100" /></label>
+      <label>SLA % (time-based) <input type="number" id="slaPct" value="95" min="0" max="100" /></label>
     </div>
     <button id="runBtn">Run Calculation</button>
   </div>


### PR DESCRIPTION
## Summary
- compute time-based, dispatch-based, and price-weighted availability metrics with headroom cost
- expose P_min and SLA inputs, and render availability KPIs with new timeline view
- document availability metrics and KPIs in revenue-loss demo README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899950d1a3c8320b7f3b3d3e461194e