### PR TITLE
feat: visualise revenue loss metrics

### DIFF
--- a/docs/revenue-loss-v2/app.test.js
+++ b/docs/revenue-loss-v2/app.test.js
@@ -22,7 +22,8 @@ const {
   calculateValueBasedAvailability,
   calculatePriceWeightedAvailability,
   calculateHeadroomCost,
-  calculateKeyMetrics
+  calculateKeyMetrics,
+  prepareRevenueChartData
 } = require('./app.js');
 const fs = require('fs');
 const path = require('path');
@@ -720,5 +721,16 @@ async function test(name, fn) {
     // Check configuration parameters
     assert.strictEqual(keyMetrics.analysisMetadata.p_min_percent, 5);
     assert.strictEqual(keyMetrics.analysisMetadata.sla_target_percent, 95);
+  });
+
+  await test('prepareRevenueChartData builds arrays', async () => {
+    const comparisonData = [
+      { ts: '2024-01-01T10:00:00Z', rev_pred_eur: 10, rev_act_eur: 8 },
+      { ts: '2024-01-01T10:05:00Z', rev_pred_eur: 5, rev_act_eur: 4 }
+    ];
+    const chartData = prepareRevenueChartData(comparisonData);
+    assert.deepStrictEqual(chartData.labels, ['2024-01-01T10:00:00Z', '2024-01-01T10:05:00Z']);
+    assert.deepStrictEqual(chartData.predicted, [10, 5]);
+    assert.deepStrictEqual(chartData.actual, [8, 4]);
   });
 })();

--- a/docs/revenue-loss-v2/index.html
+++ b/docs/revenue-loss-v2/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>BESS Revenue-Loss V2</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <h1>BESS Revenue-Loss V2</h1>
@@ -34,6 +35,8 @@
     <button id="runBtn">Run Calculation</button>
   </div>
 
+  <div id="metrics"></div>
+  <canvas id="revenueChart" width="400" height="200"></canvas>
   <pre id="output"></pre>
   <script src="./app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add key metrics summary and revenue performance chart using Chart.js
- expose helper to prepare chart data for testing
- cover chart data prep with unit tests

## Testing
- `cd docs/revenue-loss-v2 && node app.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c6b3b6d4c8320a036e1b5c0fdfc71